### PR TITLE
Exception paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ target/
 !**/src/test/**/target/
 
 ### IntelliJ IDEA ###
+.idea/*
 .idea/modules.xml
 .idea/jarRepositories.xml
 .idea/compiler.xml

--- a/src/main/java/Driver.java
+++ b/src/main/java/Driver.java
@@ -18,11 +18,7 @@ import sootup.java.core.JavaSootMethod;
 import sootup.java.core.types.JavaClassType;
 import sootup.java.core.views.JavaView;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 
 import graph.Graph;
 
@@ -85,16 +81,18 @@ public final class Driver {
      * Finds all IfStatementNode nodes that have a path to a ThrowStatementNode
      *
      * @param g the graph of a given method
+     * @return a map between ThrowStaementNode and IfStatementNode on their respective paths
      */
-    public List<Node> findThrowConditionNodes(Graph g) {
-        List<Node> throwConditionNodes = new ArrayList<>();
+    public HashMap<Node, List<Node>> findThrowConditionNodes(Graph g) {
+        HashMap<Node, List<Node>> throwConditions = new HashMap<>();
 
         List<Node> throwNodes = Graph.findThrowNodes(g);
         for (Node throwNode : throwNodes) {
             ThrowStatementNode tsn = (ThrowStatementNode) throwNode;
-            throwConditionNodes = Graph.findThrowConditions(g, tsn);
+            List<Node> throwConditionNodes = Graph.findThrowConditions(g, tsn);
+            throwConditions.put(throwNode, throwConditionNodes);
         }
 
-        return throwConditionNodes;
+        return throwConditions;
     }
 }

--- a/src/main/java/Driver.java
+++ b/src/main/java/Driver.java
@@ -1,13 +1,14 @@
+import graph.node.IfStatementNode;
+import graph.node.Node;
+import graph.node.ThrowStatementNode;
 import sootup.codepropertygraph.ast.AstCreator;
 import sootup.codepropertygraph.cdg.CdgCreator;
 import sootup.codepropertygraph.cfg.CfgCreator;
 import sootup.codepropertygraph.cpg.CpgCreator;
 import sootup.codepropertygraph.ddg.DdgCreator;
 import sootup.codepropertygraph.propertygraph.PropertyGraph;
-import sootup.codepropertygraph.propertygraph.nodes.PropertyGraphNode;
 import sootup.core.graph.StmtGraph;
 import sootup.core.inputlocation.AnalysisInputLocation;
-import sootup.core.jimple.basic.Local;
 import sootup.core.jimple.common.stmt.JThrowStmt;
 import sootup.core.jimple.common.stmt.Stmt;
 import sootup.core.model.Body;
@@ -35,18 +36,26 @@ public class Driver {
         
         methods.forEach(m -> {
             Body body = m.getBody();
-            StmtGraph graph = body.getStmtGraph();
-            Iterator<Stmt> it = graph.iterator();
+            StmtGraph<?> graph = body.getStmtGraph();
 
-            while (it.hasNext()) {
-                Stmt s = it.next();
-
+            for (Stmt s : graph) {
                 if (s instanceof JThrowStmt) {
+                    System.out.println(body);
                     graphs.add(buildControlPropertyGraph(m));
                     break;
                 }
             }
         });
+
+        List<Node> throwConditions = new ArrayList<>();
+
+        for (Graph g : graphs) {
+            List<Node> throwNodes = Graph.findThrowNodes(g);
+            for (Node throwNode : throwNodes) {
+                ThrowStatementNode tsn = (ThrowStatementNode) throwNode;
+                throwConditions = Graph.findThrowConditions(g, tsn);
+            }
+        }
 
         return graphs;
     }
@@ -62,5 +71,4 @@ public class Driver {
         PropertyGraph cpg = cpgCreator.createCpg(m);
         return Graph.fromPropertyGraph(cpg);
     }
-
 }

--- a/src/main/java/Driver.java
+++ b/src/main/java/Driver.java
@@ -54,22 +54,11 @@ public final class Driver {
 
             for (Stmt s : graph) {
                 if (s instanceof JThrowStmt) {
-                    System.out.println(body);
                     graphs.add(buildControlPropertyGraph(m));
                     break;
                 }
             }
         });
-
-        List<Node> throwConditions = new ArrayList<>();
-
-        for (Graph g : graphs) {
-            List<Node> throwNodes = Graph.findThrowNodes(g);
-            for (Node throwNode : throwNodes) {
-                ThrowStatementNode tsn = (ThrowStatementNode) throwNode;
-                throwConditions = Graph.findThrowConditions(g, tsn);
-            }
-        }
 
         return graphs;
     }
@@ -90,5 +79,22 @@ public final class Driver {
 
         PropertyGraph cpg = cpgCreator.createCpg(m);
         return Graph.fromPropertyGraph(cpg);
+    }
+
+    /**
+     * Finds all IfStatementNode nodes that have a path to a ThrowStatementNode
+     *
+     * @param g the graph of a given method
+     */
+    public List<Node> findThrowConditionNodes(Graph g) {
+        List<Node> throwConditionNodes = new ArrayList<>();
+
+        List<Node> throwNodes = Graph.findThrowNodes(g);
+        for (Node throwNode : throwNodes) {
+            ThrowStatementNode tsn = (ThrowStatementNode) throwNode;
+            throwConditionNodes = Graph.findThrowConditions(g, tsn);
+        }
+
+        return throwConditionNodes;
     }
 }

--- a/src/main/java/graph/Graph.java
+++ b/src/main/java/graph/Graph.java
@@ -1,6 +1,7 @@
 package graph;
 
-import org.jgrapht.graph.DirectedWeightedPseudograph;
+import org.jgrapht.graph.DirectedPseudograph;
+import org.jgrapht.graph.EdgeReversedGraph;
 
 import graph.edge.BooleanCFGEdge;
 import graph.edge.CFGEdge;
@@ -11,6 +12,7 @@ import graph.node.IfStatementNode;
 import graph.node.Node;
 import graph.node.SimpleNode;
 import graph.node.ThrowStatementNode;
+import org.jgrapht.traverse.DepthFirstIterator;
 import sootup.codepropertygraph.propertygraph.PropertyGraph;
 import sootup.codepropertygraph.propertygraph.edges.AbstAstEdge;
 import sootup.codepropertygraph.propertygraph.edges.CdgEdge;
@@ -25,7 +27,12 @@ import sootup.codepropertygraph.propertygraph.nodes.StmtGraphNode;
 import sootup.core.jimple.common.stmt.JIfStmt;
 import sootup.core.jimple.common.stmt.JThrowStmt;
 
-public class Graph extends DirectedWeightedPseudograph<Node, Edge> {
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+public class Graph extends DirectedPseudograph<Node, Edge> {
 
     
     private Graph() {
@@ -77,5 +84,41 @@ public class Graph extends DirectedWeightedPseudograph<Node, Edge> {
             return new IfStatementNode(node, ifStmt.getCondition());
         }
         return new SimpleNode(node);
+    }
+
+    public static List<Node> findThrowNodes(Graph g) {
+        return g
+                .vertexSet()
+                .stream()
+                .filter(n -> n.getClass().equals(ThrowStatementNode.class)).toList();
+    }
+
+    public static List<Node> findIfStmtNodes(Graph g) {
+        return g
+                .vertexSet()
+                .stream()
+                .filter(n -> n.getClass().equals(IfStatementNode.class)).toList();
+    }
+
+    /**
+     *
+     * @param g a Graph
+     * @param t a ThrowStatementNode
+     * @return a list of IfStatementNode that have a path to t
+     */
+    public static List<Node> findThrowConditions(Graph g, ThrowStatementNode t) {
+        List <Node> throwConditions = new ArrayList<>();
+        // Not sure how costly this reversal can be at scale. Doc says there is a penalty
+        // We can easily build the reversed graph if we like
+        EdgeReversedGraph<Node, Edge> reversedGraph = new EdgeReversedGraph<>(g);
+        Iterator<Node> iterator = new DepthFirstIterator<>(reversedGraph, t);
+        while (iterator.hasNext()) {
+            Node n = iterator.next();
+            if (n instanceof IfStatementNode) {
+                throwConditions.add(n);
+            }
+        }
+
+        return throwConditions;
     }
 }

--- a/src/main/java/graph/Graph.java
+++ b/src/main/java/graph/Graph.java
@@ -95,13 +95,6 @@ public class Graph extends DirectedPseudograph<Node, Edge> {
                 .filter(n -> n.getClass().equals(ThrowStatementNode.class)).toList();
     }
 
-    public static List<Node> findIfStmtNodes(Graph g) {
-        return g
-                .vertexSet()
-                .stream()
-                .filter(n -> n.getClass().equals(IfStatementNode.class)).toList();
-    }
-
     /**
      *
      * @param g a Graph

--- a/src/test/java/DriverTest.java
+++ b/src/test/java/DriverTest.java
@@ -1,5 +1,8 @@
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 
+import graph.node.Node;
 import org.junit.Test;
 
 import graph.Graph;
@@ -7,12 +10,24 @@ import graph.Graph;
 import static org.junit.Assert.*;
 
 public class DriverTest {
+    Path projectRoot = Paths.get(System.getProperty("user.dir"));
+    Path testClassesDir = projectRoot.resolve("target/test-classes");
 
     @Test
     public void buildJimple() {
         Driver driver = new Driver();
-        List<Graph> graphs = driver.execute("/home/adriano/Projects/phd/sootup-samples/target/test-classes", "br.unb.cic.samples.Math");
+        List<Graph> graphs = driver.execute(testClassesDir.toString(), "br.unb.cic.samples.Math");
         assertNotNull(graphs);
         assertEquals(1, graphs.size());
+    }
+
+    @Test
+    public void findExceptionConditionNodes() {
+        Driver driver = new Driver();
+        List<Graph> graphs = driver.execute(testClassesDir.toString(), "br.unb.cic.samples.Math");
+        assertNotNull(graphs);
+        assertEquals(1, graphs.size());
+        List<Node> throwConditionNodes = driver.findThrowConditionNodes(graphs.get(0));
+        assertEquals(1, throwConditionNodes.size());
     }
 }

--- a/src/test/java/DriverTest.java
+++ b/src/test/java/DriverTest.java
@@ -1,19 +1,18 @@
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
 import java.util.List;
 
 import org.junit.Test;
 
 import graph.Graph;
 
+import static org.junit.Assert.*;
+
 public class DriverTest {
 
     @Test
     public void buildJimple() {
         Driver driver = new Driver();
-        List<Graph> graphs = driver.execute("/Users/rbonifacio/Documents/workspace-java/sootup/target/test-classes", "br.unb.cic.samples.Math");
+        List<Graph> graphs = driver.execute("/home/adriano/Projects/phd/sootup-samples/target/test-classes", "br.unb.cic.samples.Math");
         assertNotNull(graphs);
-        assertTrue(graphs.size() == 1);
+        assertEquals(1, graphs.size());
     }
 }

--- a/src/test/java/DriverTest.java
+++ b/src/test/java/DriverTest.java
@@ -1,5 +1,6 @@
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.HashMap;
 import java.util.List;
 
 import graph.node.Node;
@@ -27,7 +28,10 @@ public class DriverTest {
         List<Graph> graphs = driver.execute(testClassesDir.toString(), "br.unb.cic.samples.Math");
         assertNotNull(graphs);
         assertEquals(1, graphs.size());
-        List<Node> throwConditionNodes = driver.findThrowConditionNodes(graphs.get(0));
-        assertEquals(1, throwConditionNodes.size());
+        List<Node> throwNodes = Graph.findThrowNodes(graphs.get(0));
+        assertEquals(1, throwNodes.size());
+        HashMap<Node, List<Node>> throwConditions = driver.findThrowConditionNodes(graphs.get(0));
+        assertEquals(1, throwConditions.size());
+        assertEquals(1, throwConditions.get(throwNodes.get(0)).size());
     }
 }


### PR DESCRIPTION
prototypes `findThrowConditions`. Given a method `m` that has 1 or more `ThrowStatementNode`'s, returns a map between the throw nodes and the `IfStatementNode`'s that have a path to the throw node.

The test is a bit brute force and suggests the code may not be great, but this is just to illustrate the idea at this stage.

Targeting the `jgrapht` branch for now as it's the latest, but I suggest we do a merge to `main` once this PR is merged