### PR TITLE
introduce z3 checking

### DIFF
--- a/src/scripts/symsolver.py
+++ b/src/scripts/symsolver.py
@@ -1,5 +1,63 @@
 import sys, json
-from sympy import And, Or, Not, simplify_logic, sympify
+from sympy import S, And, Or, Not, simplify_logic, sympify
+import z3
+from z3 import Solver, sat, unsat
+import re
+
+# on the shoulders of giants
+# https://github.com/mmaaz-git/sym2z/blob/main/sym2z.py
+def _sympy_to_z3(expr):
+    variables = set(expr.free_symbols)
+
+    expr_str = str(expr)
+    for var in variables:
+        # Add word boundaries to only replace whole variable names
+        var_str = r'\b' + str(var) + r'\b'
+        if var.is_integer:
+            expr_str = re.sub(var_str, f"z3.Int('{var}')", expr_str)
+        else:
+            expr_str = re.sub(var_str, f"z3.Real('{var}')", expr_str)
+
+    # Boolean operators
+    expr_str = expr_str.replace("And", "z3.And")
+    expr_str = expr_str.replace("Or", "z3.Or")
+    expr_str = expr_str.replace("Not", "z3.Not")
+
+    return eval(expr_str)
+
+def check_feasibility(system):
+    if not isinstance(system, list):
+        system = [system]
+
+    variables = set()
+    for expr in system:
+        variables.update(expr.free_symbols)
+
+    s = Solver()
+    for expr in system:
+        s.add(_sympy_to_z3(expr))
+
+    if s.check() == sat:
+        model = s.model()
+        result = {}
+        solutions = []
+        for var in variables:
+            z3_var = z3.Int(str(var)) if var.is_integer else z3.Real(str(var))
+            value = model.get_interp(z3_var)
+            result[var] = S(str(value))
+            solution = {
+                "variable": str(var),
+                "value": str(value)
+            }
+            solutions.append(solution)
+        return {
+            "is_sat": True,
+            "solutions": solutions,
+        }
+    elif s.check() == unsat:
+        return "unsat", {}
+    else:
+        return "unknown", {}
 
 raw = sys.stdin.read()
 throw_condition_paths = json.loads(raw)
@@ -21,4 +79,4 @@ dnf = Or(*[
 simplified = simplify_logic(dnf, form='dnf')
 
 # Outputs to stdout. Java code expects a single line atm.
-print(simplified)
+print(json.dumps(check_feasibility(simplified)))

--- a/src/test/java/MathTest.java
+++ b/src/test/java/MathTest.java
@@ -71,7 +71,8 @@ public class MathTest {
     public void findProbabilityThrowConditions() {
         Driver driver = new Driver();
         HashMap<String, WITUpGraph> graphs = driver.buildCPGForThrowingMethods(testClassesDir.toString(), "br.unb.cic.samples.Math");
-        WITUpGraph g = graphs.get("<br.unb.cic.samples.Math: double probability(int)>");
+        String methodFQN = "<br.unb.cic.samples.Math: double probability(int)>";
+        WITUpGraph g = graphs.get(methodFQN);
         List<WITUpNode> throwNodes = WITUpGraph.findThrowNodes(g);
         assertEquals(1, throwNodes.size());
 
@@ -100,8 +101,8 @@ public class MathTest {
 
             process.waitFor();
 
+            System.out.println(methodFQN);
             System.out.println("concrete throw conditions " + result);
-            System.out.println();
         } catch (IOException | InterruptedException e) {
             throw new RuntimeException(e);
         }

--- a/src/test/java/MathTest.java
+++ b/src/test/java/MathTest.java
@@ -100,7 +100,8 @@ public class MathTest {
 
             process.waitFor();
 
-            System.out.println("SymPy to z3 yields back: " + result);
+            System.out.println("concrete throw conditions " + result);
+            System.out.println();
         } catch (IOException | InterruptedException e) {
             throw new RuntimeException(e);
         }

--- a/src/test/java/MathTest.java
+++ b/src/test/java/MathTest.java
@@ -100,7 +100,7 @@ public class MathTest {
 
             process.waitFor();
 
-            System.out.println("Python returned: " + result);
+            System.out.println("SymPy to z3 yields back: " + result);
         } catch (IOException | InterruptedException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
our first round trip!

Running the `findProbabilityThrowConditions` test will now invoke the updated symsolver.py script that streamlines a SymPy -> z3 pipeline.

running the test will now result in:

```bash
<br.unb.cic.samples.Math: double probability(int)>
concrete throw conditions {"is_sat": true, "solutions": [{"variable": "p", "value": "-1"}]}
```